### PR TITLE
fix(ci): require PROJECT_NAME secret to prevent deployment misconfiguration

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -135,7 +135,15 @@ jobs:
           fi
           
           # Get the kubeconfig from the cluster stack output
-          PROJECT_NAME="${{ secrets.PROJECT_NAME || 'my-company' }}"
+          # Validate PROJECT_NAME secret is set to avoid misconfiguration
+          if [[ -z "${{ secrets.PROJECT_NAME }}" ]]; then
+            echo "Error: PROJECT_NAME secret is not set"
+            echo "This secret is required to determine the correct CDKTF stack name"
+            echo "Please set the PROJECT_NAME secret in your repository settings"
+            exit 1
+          fi
+          
+          PROJECT_NAME="${{ secrets.PROJECT_NAME }}"
           STACK_NAME="${PROJECT_NAME}-production"
           
           # Validate stack exists in output


### PR DESCRIPTION
## Summary
- Remove dangerous fallback 'my-company' default value for PROJECT_NAME
- Add explicit validation that PROJECT_NAME secret is set before deployment
- Provide clear error message when secret is missing

## Problem
The current workflow uses a fallback value of 'my-company' when PROJECT_NAME secret is not set, which could lead to unintended deployments to the wrong infrastructure stack in production environments.

## Solution
- Explicitly check if PROJECT_NAME secret is set
- Fail fast with clear error message if missing
- Remove the unsafe fallback default

## Test plan
- [ ] Verify deployment fails gracefully when PROJECT_NAME is not set
- [ ] Confirm deployment works correctly when PROJECT_NAME is properly configured
- [ ] Validate error message provides clear guidance for fixing the issue