### PR TITLE
fix: resolve template cleanup issue creation failures

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -707,6 +707,7 @@ This will remove all template-specific files automatically.
         this.log('Created template-cleanup label');
       } catch {
         // Label might already exist, continue silently
+        this.log(`${colors.yellow}Label 'template-cleanup' already exists; skipping creation.${colors.reset}`);
       }
 
       // Use heredoc to avoid shell interpretation of backticks
@@ -716,7 +717,11 @@ EOF
 )" --label "template-cleanup"`;
       
       const result = this.exec(command, true);
-      this.logSuccess(`Created template cleanup issue: ${result.trim()}`);
+      if (result && typeof result === 'string') {
+        this.logSuccess(`Created template cleanup issue: ${result.trim()}`);
+      } else {
+        this.logWarning('Failed to retrieve result from GitHub CLI command');
+      }
       
     } catch (error: any) {
       this.logWarning('Failed to create template cleanup issue');

--- a/setup.ts
+++ b/setup.ts
@@ -650,6 +650,15 @@ class GitOpsSetup {
       return;
     }
 
+    // Validate GitHub authentication before attempting operations
+    try {
+      this.exec('gh auth status', true);
+    } catch (error) {
+      this.logWarning('GitHub authentication required. Run: gh auth login');
+      this.logWarning('Skipping template cleanup issue creation');
+      return;
+    }
+
     const issueBody = `## Template Cleanup Required
 
 This issue was automatically created after repository setup to track cleanup of template artifacts.
@@ -692,11 +701,38 @@ This will remove all template-specific files automatically.
 *This issue was created automatically by the GitOps template setup process.*`;
 
     try {
-      this.exec(`gh issue create --title "chore: complete template cleanup and ejection" --body "${issueBody.replace(/"/g, '\\"')}" --label "template-cleanup"`, true);
-      this.logSuccess('Created template cleanup issue');
-    } catch (error) {
-      this.logWarning(`Could not create GitHub issue: ${error}`);
-      this.logWarning('You may need to authenticate with: gh auth login');
+      // Create template-cleanup label if it doesn't exist
+      try {
+        this.exec('gh label create "template-cleanup" --description "Issues related to template cleanup and ejection" --color "5319e7"', true);
+        this.log('Created template-cleanup label');
+      } catch {
+        // Label might already exist, continue silently
+      }
+
+      // Use heredoc to avoid shell interpretation of backticks
+      const command = `gh issue create --title "chore: complete template cleanup and ejection" --body "$(cat <<'EOF'
+${issueBody}
+EOF
+)" --label "template-cleanup"`;
+      
+      const result = this.exec(command, true);
+      this.logSuccess(`Created template cleanup issue: ${result.trim()}`);
+      
+    } catch (error: any) {
+      this.logWarning('Failed to create template cleanup issue');
+      
+      // Provide specific error context
+      if (error.message.includes('not found')) {
+        this.logWarning('GitHub CLI (gh) not found. Install with: nix-shell -p github-cli');
+      } else if (error.message.includes('permission') || error.message.includes('auth')) {
+        this.logWarning('GitHub authentication issue. Run: gh auth login');
+      } else if (error.message.includes('template-cleanup')) {
+        this.logWarning('Label issue - this has been fixed for future runs');
+      } else {
+        this.logWarning(`Unexpected error: ${error.message}`);
+      }
+      
+      this.logWarning('You can create the cleanup issue manually or re-run setup with proper authentication');
     }
   }
 


### PR DESCRIPTION
## Summary
Fixes #100 - Template cleanup issue creation was failing due to shell command substitution errors.

## Problem
The `createCleanupIssue()` method in `setup.ts` was constructing GitHub CLI commands incorrectly, causing:
- `setup.ts: not found` errors when shell tried to execute backtick content as commands  
- `Permission denied` errors when trying to execute directory paths
- Missing `template-cleanup` label causing label creation failures

## Root Cause
The issue body contained backticks (`` `setup.ts` ``) that were being interpreted by the shell as command substitution instead of literal text.

## Solution
### Fixed Shell Command Substitution
- Replaced direct string interpolation with heredoc pattern: `cat <<'EOF'`
- Prevents shell from interpreting backticks as commands
- Follows same pattern used successfully in GitHub workflows

### Enhanced Error Handling  
- Added GitHub authentication validation before attempting operations
- Automatic creation of `template-cleanup` label if missing
- Specific error messages for different failure modes (auth, missing tools, etc.)
- Clear guidance for manual resolution when automated process fails

### Code Quality Improvements
- Better error context and user guidance
- Defensive programming against missing labels
- Proper validation of prerequisites

## Test Plan
- [x] TypeScript compilation passes
- [x] Fixed heredoc pattern prevents command substitution
- [x] Error handling provides clear guidance
- [ ] Verify in CI that setup script dry-run works
- [ ] Test actual issue creation when GitHub auth is available

## Breaking Changes
None - this only fixes existing functionality.

## Files Changed
- `setup.ts` - Fixed createCleanupIssue() method with proper shell escaping and error handling