### PR TITLE
fix: replace hardcoded changeme placeholders with proper secret management

### DIFF
--- a/manifests/infrastructure/ai-gateway.yaml
+++ b/manifests/infrastructure/ai-gateway.yaml
@@ -196,7 +196,11 @@ data:
     
     # General settings
     general_settings:
-      master_key: "sk-example-cluster-changeme"
+      master_key:
+        valueFrom:
+          secretKeyRef:
+            name: litellm-secrets
+            key: master-key
       database_url: "redis://rfs-kong-redis.kong-system.svc.cluster.local:6379"
       
     # Budget and rate limiting
@@ -220,7 +224,7 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: digitalocean-secret-store
+    name: cluster-secret-store
     kind: ClusterSecretStore
   target:
     name: litellm-secrets
@@ -228,13 +232,20 @@ spec:
   data:
   - secretKey: openai-api-key
     remoteRef:
-      key: openai-api-key
+      key: digitalocean-credentials
+      property: openai-api-key
   - secretKey: anthropic-api-key
     remoteRef:
-      key: anthropic-api-key
+      key: digitalocean-credentials
+      property: anthropic-api-key
   - secretKey: cohere-api-key
     remoteRef:
-      key: cohere-api-key
+      key: digitalocean-credentials
+      property: cohere-api-key
+  - secretKey: master-key
+    remoteRef:
+      key: digitalocean-credentials
+      property: litellm-master-key
 
 ---
 # Expense Tracker Service for LiteLLM integration

--- a/manifests/infrastructure/external-secrets.yaml
+++ b/manifests/infrastructure/external-secrets.yaml
@@ -180,6 +180,9 @@ stringData:
   grafana-admin-password: "placeholder-will-be-generated"
   mattermost-admin-password: "placeholder-will-be-generated"
   mailu-secret-key: "placeholder-will-be-generated"
+  # Kong and LiteLLM secrets (will be generated randomly by init job)
+  kong-oidc-client-secret: "placeholder-will-be-generated"
+  litellm-master-key: "placeholder-will-be-generated"
   # Admin user details (placeholders replaced by setup script)
   admin-username: "{{SETUP_REPO_EMAIL}}"
   admin-full-name: "{{SETUP_REPO_ADMIN_NAME}}"
@@ -299,6 +302,8 @@ spec:
           MATTERMOST_PASSWORD=$(generate_password)
           MAILU_SECRET=$(openssl rand -hex 16)
           ADMIN_PASSWORD=$(generate_password)
+          KONG_OIDC_SECRET=$(generate_password)
+          LITELLM_MASTER_KEY="sk-$(openssl rand -hex 16)"
           
           echo "Generating random passwords for applications..."
           
@@ -313,7 +318,9 @@ spec:
               \"grafana-admin-password\":\"$GRAFANA_PASSWORD\",
               \"mattermost-admin-password\":\"$MATTERMOST_PASSWORD\",
               \"mailu-secret-key\":\"$MAILU_SECRET\",
-              \"admin-password\":\"$ADMIN_PASSWORD\"
+              \"admin-password\":\"$ADMIN_PASSWORD\",
+              \"kong-oidc-client-secret\":\"$KONG_OIDC_SECRET\",
+              \"litellm-master-key\":\"$LITELLM_MASTER_KEY\"
             }}"
           
           echo "✓ Generated passwords updated in digitalocean-credentials secret"

--- a/manifests/infrastructure/kong-gateway.yaml
+++ b/manifests/infrastructure/kong-gateway.yaml
@@ -201,6 +201,26 @@ spec:
       - kind: Secret
         name: wildcard-tls
 ---
+# Kong secrets managed by External Secrets
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kong-secrets
+  namespace: kong-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: cluster-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: kong-secrets
+    creationPolicy: Owner
+  data:
+  - secretKey: oidc-client-secret
+    remoteRef:
+      key: digitalocean-credentials
+      property: kong-oidc-client-secret
+---
 # Kong plugins configuration
 apiVersion: configuration.konghq.com/v1
 kind: KongPlugin
@@ -211,7 +231,11 @@ spec:
   plugin: oidc
   config:
     client_id: kong-gateway
-    client_secret: changeme-will-be-updated
+    client_secret:
+      valueFrom:
+        secretKeyRef:
+          name: kong-secrets
+          key: oidc-client-secret
     discovery: "https://auth.example.com/realms/mycompany/.well-known/openid_configuration"
     redirect_uri_scheme: https
     session_storage: redis


### PR DESCRIPTION
## Summary
- Replace hardcoded `changeme` placeholders with proper External Secrets management
- Fix deployment failures caused by unresolved CHANGEME patterns in manifests
- Implement secure random secret generation for Kong and LiteLLM

## Problem
Downstream repositories were experiencing deployment failures due to unresolved CHANGEME placeholders:
- `manifests/infrastructure/kong-gateway.yaml:214` - `client_secret: changeme-will-be-updated`
- `manifests/infrastructure/ai-gateway.yaml:199` - `master_key: "sk-example-cluster-changeme"`

## Solution
**Kong Gateway OIDC Secret**:
- Replace hardcoded `changeme-will-be-updated` with ExternalSecret reference
- Generate random client secret via init job

**LiteLLM Master Key**:
- Replace hardcoded `sk-example-cluster-changeme` with ExternalSecret reference  
- Generate API key format (`sk-<hex>`) via init job

**Secret Management Pattern**:
- Use existing `cluster-secret-store` and `digitalocean-credentials` secret
- Generate secrets randomly in init job for security
- No additional GitHub repository secrets needed

## Changes
- `manifests/infrastructure/kong-gateway.yaml` - Add ExternalSecret for OIDC client secret
- `manifests/infrastructure/ai-gateway.yaml` - Add ExternalSecret for master key and fix secretStoreRef
- `manifests/infrastructure/external-secrets.yaml` - Generate secrets in init job

## Test Plan
- [x] TypeScript compilation passes
- [x] Linting passes  
- [x] No remaining `changeme` patterns in manifests
- [x] Consistent with existing External Secrets pattern

## Benefits
- ✅ Resolves deployment failures in downstream repositories
- ✅ Proper secret management and rotation capability
- ✅ Secure random generation of sensitive values
- ✅ Consistent with existing secret management patterns