### PR TITLE
fix: exclude .github directory from CHANGEME check

### DIFF
--- a/.github/actions/check-setup/action.yml
+++ b/.github/actions/check-setup/action.yml
@@ -254,6 +254,7 @@ runs:
           --exclude-dir=docs \
           --exclude-dir=platform \
           --exclude-dir=manifests \
+          --exclude-dir=.github \
           . >/dev/null 2>&1; then
           SETUP_COMPLETE=false
           MISSING_ITEMS="$MISSING_ITEMS- Critical template placeholders (CHANGEME) still present\n"


### PR DESCRIPTION
The check-setup action was detecting its own references to 'CHANGEME' in comments and error messages, causing false positives.