### PR TITLE
feat(security): add network policies to application namespaces

### DIFF
--- a/manifests/applications/ai-gateway/kustomization.yaml
+++ b/manifests/applications/ai-gateway/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - external-secret.yaml
 - routes.yaml
 - service-monitor.yaml
+- network-policy.yaml

--- a/manifests/applications/ai-gateway/network-policy.yaml
+++ b/manifests/applications/ai-gateway/network-policy.yaml
@@ -1,0 +1,104 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: litellm-network-policy
+  namespace: ai-gateway
+spec:
+  podSelector:
+    matchLabels:
+      app: litellm
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow traffic from Kong Gateway
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: kong
+    ports:
+    - protocol: TCP
+      port: 4000
+  # Allow traffic from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 4000
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow HTTPS outbound for AI provider APIs (OpenAI, Anthropic, etc.)
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow access to Redis for caching
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: redis-system
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: redis
+    ports:
+    - protocol: TCP
+      port: 6379
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: expense-tracker-network-policy
+  namespace: ai-gateway
+spec:
+  podSelector:
+    matchLabels:
+      app: expense-tracker
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow traffic from Kong Gateway
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: kong
+    ports:
+    - protocol: TCP
+      port: 3000
+  # Allow traffic from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 3000
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to LiteLLM for AI functionality
+  - to:
+    - podSelector:
+        matchLabels:
+          app: litellm
+    ports:
+    - protocol: TCP
+      port: 4000
+  # Allow HTTPS outbound for external APIs
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443

--- a/manifests/applications/keycloak/kustomization.yaml
+++ b/manifests/applications/keycloak/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - certificates.yaml
   - keycloak.yaml
   - routes.yaml
+  - network-policy.yaml
 
 # Dependencies managed at the Flux level
 # This namespace depends on keycloak-operator being ready

--- a/manifests/applications/keycloak/network-policy.yaml
+++ b/manifests/applications/keycloak/network-policy.yaml
@@ -1,0 +1,115 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: keycloak-network-policy
+  namespace: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app: keycloak
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow traffic from Kong Gateway
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: kong
+    ports:
+    - protocol: TCP
+      port: 8080
+    - protocol: TCP
+      port: 8443
+  # Allow traffic from other applications for OIDC
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: mattermost
+    - namespaceSelector:
+        matchLabels:
+          name: nextcloud
+    - namespaceSelector:
+        matchLabels:
+          name: mailu
+    - namespaceSelector:
+        matchLabels:
+          name: postal
+    ports:
+    - protocol: TCP
+      port: 8080
+  # Allow traffic from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9990
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: keycloak-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow HTTPS outbound for external integrations
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: keycloak-postgres-network-policy
+  namespace: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      postgresql.cnpg.io/cluster: keycloak-postgres
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from Keycloak pods
+  - from:
+    - podSelector:
+        matchLabels:
+          app: keycloak
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9187
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow PostgreSQL cluster communication
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: keycloak-postgres
+    ports:
+    - protocol: TCP
+      port: 5432

--- a/manifests/applications/mattermost/kustomization.yaml
+++ b/manifests/applications/mattermost/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - routes.yaml
   - certificates.yaml
   - service-monitor.yaml
+  - network-policy.yaml
 
 patches:
   # Mattermost depends on infrastructure being ready

--- a/manifests/applications/mattermost/network-policy.yaml
+++ b/manifests/applications/mattermost/network-policy.yaml
@@ -1,0 +1,107 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mattermost-network-policy
+  namespace: mattermost
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mattermost
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow traffic from Kong Gateway
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: kong
+    ports:
+    - protocol: TCP
+      port: 8065
+  # Allow traffic from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 8067
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: mattermost-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow HTTPS outbound for OIDC with Keycloak and external integrations
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow access to Keycloak for OIDC
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: keycloak
+    - podSelector:
+        matchLabels:
+          app: keycloak
+    ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mattermost-postgres-network-policy
+  namespace: mattermost
+spec:
+  podSelector:
+    matchLabels:
+      postgresql.cnpg.io/cluster: mattermost-postgres
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from Mattermost pods
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: mattermost
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9187
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow PostgreSQL cluster communication
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: mattermost-postgres
+    ports:
+    - protocol: TCP
+      port: 5432

--- a/manifests/applications/nextcloud/kustomization.yaml
+++ b/manifests/applications/nextcloud/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - routes.yaml
   - certificates.yaml
   - service-monitor.yaml
+  - network-policy.yaml
 
 patches:
   # Nextcloud depends on infrastructure being ready

--- a/manifests/applications/nextcloud/network-policy.yaml
+++ b/manifests/applications/nextcloud/network-policy.yaml
@@ -1,0 +1,142 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: nextcloud-network-policy
+  namespace: nextcloud
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: nextcloud
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow traffic from Kong Gateway
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: kong
+    ports:
+    - protocol: TCP
+      port: 80
+  # Allow traffic from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9205
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: nextcloud-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow access to Redis
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: redis
+    ports:
+    - protocol: TCP
+      port: 6379
+  # Allow HTTPS outbound for external integrations and DigitalOcean Spaces
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: nextcloud-postgres-network-policy
+  namespace: nextcloud
+spec:
+  podSelector:
+    matchLabels:
+      postgresql.cnpg.io/cluster: nextcloud-postgres
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from Nextcloud pods
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: nextcloud
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9187
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow PostgreSQL cluster communication
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: nextcloud-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: nextcloud-redis-network-policy
+  namespace: nextcloud
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from Nextcloud pods
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: nextcloud
+    ports:
+    - protocol: TCP
+      port: 6379
+  # Allow connections from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9121
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53


### PR DESCRIPTION
## Summary
- Added comprehensive network policies for Nextcloud, Mattermost, Keycloak, and ai-gateway namespaces
- Implemented zero-trust networking principles with explicit allow rules
- Separated policies for application and database components

## Changes Made
- **Nextcloud**: Network policies for app, PostgreSQL, and Redis pods
- **Mattermost**: Network policies for app and PostgreSQL pods  
- **Keycloak**: Network policies for app and PostgreSQL pods
- **ai-gateway**: Network policies for LiteLLM and expense-tracker pods

## Security Improvements
- Restricts ingress to only Kong Gateway and monitoring systems
- Allows necessary egress for DNS resolution, databases, and external APIs
- Enables cross-namespace communication for OIDC authentication flows
- Implements defense-in-depth by isolating application components

## Test Plan
- [x] Created network policy YAML files with proper selectors
- [x] Added network policies to kustomization.yaml files
- [ ] Deploy to test cluster and verify connectivity
- [ ] Test application functionality remains intact
- [ ] Verify monitoring and OIDC flows work correctly
- [ ] Confirm external integrations (Spaces, AI APIs) still function

Fixes #143
Fixes #141
Fixes #134  
Fixes #128