### PR TITLE
fix(security): use specific image tag for LiteLLM deployment

### DIFF
--- a/manifests/applications/ai-gateway/litellm-deployment.yaml
+++ b/manifests/applications/ai-gateway/litellm-deployment.yaml
@@ -20,7 +20,9 @@ spec:
     spec:
       containers:
       - name: litellm
-        image: ghcr.io/berriai/litellm:main-latest
+        # Using specific version tag instead of 'latest' for predictable deployments
+        # Update process: Test new versions in staging before updating this tag
+        image: ghcr.io/berriai/litellm:v1.72.6-stable
         ports:
         - containerPort: 4000
           name: http

--- a/manifests/applications/ai-gateway/network-policy.yaml
+++ b/manifests/applications/ai-gateway/network-policy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: litellm
+      app: litellm-proxy
   policyTypes:
   - Ingress
   - Egress
@@ -93,7 +93,7 @@ spec:
   - to:
     - podSelector:
         matchLabels:
-          app: litellm
+          app: litellm-proxy
     ports:
     - protocol: TCP
       port: 4000


### PR DESCRIPTION
## Summary
- Replaced 'latest' tag with specific version v1.72.6-stable for LiteLLM
- Added documentation comments for version management
- Fixed network policy pod selectors to match deployment labels

## Changes Made
- Updated `litellm-deployment.yaml` to use `ghcr.io/berriai/litellm:v1.72.6-stable`
- Added comments explaining version selection and update process
- Fixed network policy to use correct `app: litellm-proxy` label selector

## Security Benefits
- Predictable deployments with no unexpected changes
- Reduced risk of breaking changes in production
- Controlled version update process
- Improved supply chain security

## Test Plan
- [x] Verified v1.72.6-stable is a recent stable release
- [x] Updated deployment manifest with specific version
- [x] Fixed label selector inconsistency
- [ ] Deploy to test cluster and verify LiteLLM starts correctly
- [ ] Test AI gateway functionality with pinned version
- [ ] Verify expense tracker webhook integration works

Fixes #129