### PR TITLE
feat(security): harden Mailu with security contexts and network policies

### DIFF
--- a/manifests/applications/mailu/helm-release.yaml
+++ b/manifests/applications/mailu/helm-release.yaml
@@ -75,6 +75,22 @@ spec:
         storageClass: do-block-storage
         accessMode: ReadWriteMany
       
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: false  # Required for mail server operations
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - NET_BIND_SERVICE  # Required for binding to privileged ports
+            - SETGID           # Required for mail operations
+            - SETUID           # Required for mail operations
+      
       # Service configuration
       service:
         type: LoadBalancer
@@ -108,6 +124,18 @@ spec:
         size: 2Gi
         storageClass: do-block-storage
         accessMode: ReadWriteOnce
+      
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: true   # Admin interface can run as non-root
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
     
     # Postfix SMTP server
     postfix:
@@ -124,6 +152,24 @@ spec:
         size: 2Gi
         storageClass: do-block-storage
         accessMode: ReadWriteOnce
+      
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: false  # Postfix requires root for mail operations
+        runAsUser: 0         # Required for postfix operations
+        runAsGroup: 0
+        fsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - NET_BIND_SERVICE  # Required for SMTP ports
+            - SETGID           # Required for mail operations
+            - SETUID           # Required for mail operations
+            - CHOWN            # Required for mail file operations
+            - DAC_OVERRIDE     # Required for mail file access
       
       # Postfix configuration
       messageSizeLimitMb: 50
@@ -157,6 +203,24 @@ spec:
         size: 10Gi
         storageClass: do-block-storage
         accessMode: ReadWriteMany
+      
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: false  # Dovecot requires root for mail operations
+        runAsUser: 0         # Required for dovecot operations
+        runAsGroup: 0
+        fsGroup: 0
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
+          add:
+            - NET_BIND_SERVICE  # Required for IMAP ports
+            - SETGID           # Required for mail operations
+            - SETUID           # Required for mail operations
+            - CHOWN            # Required for mail file operations
+            - DAC_OVERRIDE     # Required for mail file access
     
     # Rspamd spam filter
     rspamd:
@@ -173,6 +237,18 @@ spec:
         size: 1Gi
         storageClass: do-block-storage
         accessMode: ReadWriteOnce
+      
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: true   # Rspamd can run as non-root
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
     
     # ClamAV antivirus
     clamav:
@@ -189,6 +265,18 @@ spec:
         size: 2Gi
         storageClass: do-block-storage
         accessMode: ReadWriteOnce
+      
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: true   # ClamAV can run as non-root
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
     
     # Webmail (Roundcube)
     webmail:
@@ -206,6 +294,18 @@ spec:
         size: 1Gi
         storageClass: do-block-storage
         accessMode: ReadWriteOnce
+      
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: true   # Roundcube can run as non-root
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
     
     # Webdav support
     webdav:
@@ -218,6 +318,18 @@ spec:
         limits:
           cpu: 500m
           memory: 256Mi
+      
+      # Security context hardening
+      securityContext:
+        runAsNonRoot: true   # WebDAV can run as non-root
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+        capabilities:
+          drop:
+            - ALL
     
     # Fetchmail
     fetchmail:

--- a/manifests/applications/mailu/kustomization.yaml
+++ b/manifests/applications/mailu/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - routes.yaml
   - certificates.yaml
   - service-monitor.yaml
+  - network-policy.yaml
 
 patches:
   # Mailu depends on infrastructure being ready

--- a/manifests/applications/mailu/network-policy.yaml
+++ b/manifests/applications/mailu/network-policy.yaml
@@ -1,0 +1,182 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mailu-network-policy
+  namespace: mailu
+spec:
+  podSelector: {}  # Apply to all pods in namespace
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow traffic from Kong Gateway for admin interface
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: kong
+    ports:
+    - protocol: TCP
+      port: 80
+  # Allow traffic from OAuth2 proxy
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: oauth2-proxy
+    ports:
+    - protocol: TCP
+      port: 80
+  # Allow mail traffic from LoadBalancer (external)
+  - from: []
+    ports:
+    - protocol: TCP
+      port: 25    # SMTP
+    - protocol: TCP
+      port: 587   # SMTP Submission
+    - protocol: TCP
+      port: 993   # IMAPS
+    - protocol: TCP
+      port: 995   # POP3S
+    - protocol: TCP
+      port: 143   # IMAP
+  # Allow traffic from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9154
+  # Allow inter-pod communication within namespace
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: mailu
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow access to PostgreSQL
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: mailu-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow access to Redis
+  - to:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: redis
+    ports:
+    - protocol: TCP
+      port: 6379
+  # Allow HTTPS outbound for AWS SES and external services
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 443
+  # Allow SMTP outbound for AWS SES
+  - to: []
+    ports:
+    - protocol: TCP
+      port: 587
+  # Allow access to Keycloak for OAuth2 proxy
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: keycloak
+    - podSelector:
+        matchLabels:
+          app: keycloak
+    ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mailu-postgres-network-policy
+  namespace: mailu
+spec:
+  podSelector:
+    matchLabels:
+      postgresql.cnpg.io/cluster: mailu-postgres
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from Mailu components
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: mailu
+    ports:
+    - protocol: TCP
+      port: 5432
+  # Allow connections from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9187
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow PostgreSQL cluster communication
+  - to:
+    - podSelector:
+        matchLabels:
+          postgresql.cnpg.io/cluster: mailu-postgres
+    ports:
+    - protocol: TCP
+      port: 5432
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mailu-redis-network-policy
+  namespace: mailu
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Allow connections from Mailu components
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: mailu
+    ports:
+    - protocol: TCP
+      port: 6379
+  # Allow connections from prometheus for monitoring
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: monitoring
+    ports:
+    - protocol: TCP
+      port: 9121
+  egress:
+  # Allow DNS resolution
+  - to: []
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53


### PR DESCRIPTION
## Summary
- Implement security contexts for all Mailu components with minimal required capabilities
- Add network policies for zero-trust networking in Mailu namespace
- Non-root containers: admin, rspamd, clamav, webmail, webdav
- Root containers (mail requirements): front, postfix, dovecot with restricted capabilities

## Issues Addressed
- Fixes #135: Reduce capabilities for non-root Mailu containers
- Fixes #137: Implement Mailu network policies

## Security Improvements
- All containers run with `seccompProfile: RuntimeDefault`
- Capabilities dropped to `ALL` then selectively added as needed
- Network policies restrict ingress/egress to necessary traffic only
- Mail server components retain minimal required root capabilities

## Test Plan
- [ ] Verify Mailu pods start successfully with new security contexts
- [ ] Test mail sending/receiving functionality
- [ ] Verify network policies don't block required traffic
- [ ] Check admin interface accessibility through Kong