### PR TITLE
fix(security): remove continue-on-error from pnpm audit step

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -103,7 +103,6 @@ jobs:
       
     - name: Run security audit
       run: pnpm audit --audit-level moderate
-      continue-on-error: true
       
     - name: Check for secrets in code
       uses: trufflesecurity/trufflehog@main


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from pnpm audit step in PR checks workflow
- Ensures security vulnerabilities fail the CI pipeline

## Issue Addressed
- Fixes #153: Fail Workflow on Security Vulnerabilities

## Changes
- Removed line 106 (`continue-on-error: true`) from `.github/workflows/pr-checks.yml`
- Security audit will now fail the workflow when vulnerabilities at moderate level or higher are found

## Test Plan
- [ ] PR checks should pass if no security vulnerabilities exist
- [ ] PR checks should fail if pnpm audit finds moderate or higher vulnerabilities
- [ ] All other workflow checks continue to function normally